### PR TITLE
Use vtt.js for track element emulation

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "./dist/video-js/video.js",
   "dependencies": {
     "videojs-swf": "4.5.1",
-    "vtt.js": "git+https://github.com/mozilla/vtt.js.git#v0.11.11"
+    "vtt.js": "git+https://github.com/gkatsev/vtt.js.git#custom-build"
   },
   "devDependencies": {
     "calcdeps": "~0.1.7",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "main": "./dist/video-js/video.js",
   "dependencies": {
-    "videojs-swf": "4.5.1"
+    "videojs-swf": "4.5.1",
+    "vtt.js": "git+https://github.com/mozilla/vtt.js.git#v0.11.11"
   },
   "devDependencies": {
     "calcdeps": "~0.1.7",

--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -960,31 +960,13 @@ body.vjs-full-window {
 /* Text Track Styles */
 /* Overall track holder for both captions and subtitles */
 .video-js .vjs-text-track-display {
-  text-align: center;
   position: absolute;
-  bottom: 4em;
-  /* Leave padding on left and right *///
-  left: 1em;
-  right: 1em;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  pointer-events: none;
 }
-
-/* Move captions down when controls aren't being shown */
-.video-js.vjs-user-inactive.vjs-playing .vjs-text-track-display {
-  bottom: 1em;
-}
-
-/* Individual tracks */
-.video-js .vjs-text-track {
-  display: none;
-  font-size: 1.4em;
-  text-align: center;
-  margin-bottom: 0.1em;
-  /* Transparent black background, or fallback to all black (oldIE) *///
-  .background-color-with-alpha(rgb(0, 0, 0), 0.5);
-}
-.video-js .vjs-subtitles { color: #fff /* Subtitles are white */; }
-.video-js .vjs-captions { color: #fc6 /* Captions are yellow */; }
-.vjs-tt-cue { display: block; }
 
 /* Increase font-size when fullscreen */
 .video-js.vjs-fullscreen .vjs-text-track { font-size: 3em; }

--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -39,7 +39,7 @@ vjs.Html5 = vjs.MediaTechController.extend({
     if (supportsTextTracks && vjs.IS_FIREFOX) {
       supportsTextTracks = false;
     }
-    this['featuresTextTracks'] = supportsTextTracks;
+    this['featuresTextTracks'] = options.nativeCaptions !== false && supportsTextTracks;
 
     vjs.MediaTechController.call(this, player, options, ready);
     this.setupTriggers();

--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -305,14 +305,6 @@ vjs.MediaTechController.prototype.addTextTrack = function(kind, label, language,
   // Create correct texttrack class. CaptionsTrack, etc.
   var track = new window['videojs'][Kind + 'Track'](this.player_, options);
 
-  // lazy load vtt.js
-  if (!window.WebVTT) {
-    var script = document.createElement('script');
-    script.src = '../node_modules/vtt.js/dist/vtt.js';
-    this.el().appendChild(script);
-    window.WebVTT = true;
-  }
-
   tracks.push(track);
 
   // If track.dflt() is set, start showing immediately

--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -305,6 +305,14 @@ vjs.MediaTechController.prototype.addTextTrack = function(kind, label, language,
   // Create correct texttrack class. CaptionsTrack, etc.
   var track = new window['videojs'][Kind + 'Track'](this.player_, options);
 
+  // lazy load vtt.js
+  if (!window.WebVTT) {
+    var script = document.createElement('script');
+    script.src = '../node_modules/vtt.js/dist/vtt.js';
+    this.el().appendChild(script);
+    window.WebVTT = true;
+  }
+
   tracks.push(track);
 
   // If track.dflt() is set, start showing immediately

--- a/src/js/tracks.js
+++ b/src/js/tracks.js
@@ -436,13 +436,13 @@ vjs.TextTrack.prototype.parseCues = function(srcContent) {
   }
 
   cues = this.cues_;
-  parser = new WebVTT.Parser(window, WebVTT.StringDecoder());
+  parser = new window.WebVTT.Parser(window, window.WebVTT.StringDecoder());
   parser.oncue = function(cue) {
     cues.push(cue);
   };
   parser.onparsingerror = function(error) {
     vjs.log(error);
-  }
+  };
 
   parser.parse(srcContent);
   parser.flush();
@@ -603,11 +603,7 @@ vjs.TextTrack.prototype.update = function(){
 
 // Add cue HTML to display
 vjs.TextTrack.prototype.updateDisplay = function(){
-  var cues = this.activeCues_,
-      html = '',
-      i=0,j=cues.length;
-
-  WebVTT.processCues(window, cues, this.el_)
+  window.WebVTT.processCues(window, this.activeCues_, this.el_);
 };
 
 // Set all loop helper values back

--- a/src/js/tracks.js
+++ b/src/js/tracks.js
@@ -120,7 +120,7 @@ vjs.TextTrack = vjs.Component.extend({
     // lazy load vtt.js
     if (!window.WebVTT) {
       script = document.createElement('script');
-      script.src = options['vtt.js'] || '../node_modules/vtt.js/dist/vtt.js';
+      script.src = player.options()['vtt.js'] || '../node_modules/vtt.js/dist/vtt.js';
       player.el().appendChild(script);
       window.WebVTT = true;
     }

--- a/test/unit/tracks.js
+++ b/test/unit/tracks.js
@@ -23,41 +23,6 @@ test('cue time parsing', function() {
   equal(parse('11:11:11.111'), 40271.111, 'Hours, minutes, seconds, decimals (11:11:11.111)');
 });
 
-test('cue parsing', function() {
-  var mockTrack = {
-    cues_: [],
-    reset: function(){ this.cues_ = []; },
-    parseCues: vjs.TextTrack.prototype.parseCues,
-    parseCueTime: vjs.TextTrack.prototype.parseCueTime,
-    trigger: function(){}
-  };
-  var vttHead = 'WEBVTT\n\n';
-
-  var timeWithSpaces = vttHead + '00:00.700 --> 00:04.110\nText line 1';
-  mockTrack.parseCues(timeWithSpaces);
-  equal(mockTrack.cues_[0].startTime, 0.7, 'Cue start time w/ spaces');
-  equal(mockTrack.cues_[0].endTime, 4.11, 'Cue end time w/ spaces');
-  equal(mockTrack.cues_[0].text, 'Text line 1', 'Cue text');
-
-  mockTrack.reset(); // reset mock track
-  var timeWithTabs = vttHead + '00:00.700\t-->\t00:04.110\nText line 1';
-  mockTrack.parseCues(timeWithTabs);
-  equal(mockTrack.cues_[0].startTime, 0.7, 'Cue start time w/ spaces');
-  equal(mockTrack.cues_[0].endTime, 4.11, 'Cue end time w/ spaces');
-
-  mockTrack.reset(); // reset mock track
-  var timeWithMixedWhiteSpace = vttHead + '00:00.700  -->\t 00:04.110\nText line 1';
-  mockTrack.parseCues(timeWithMixedWhiteSpace);
-  equal(mockTrack.cues_[0].startTime, 0.7, 'Cue start time w/ spaces');
-  equal(mockTrack.cues_[0].endTime, 4.11, 'Cue end time w/ spaces');
-
-  mockTrack.reset(); // reset mock track
-  var timeWithFlags = vttHead + '00:00.700  -->\t 00:04.110 line:90% position:26% size:9%\nText line 1';
-  mockTrack.parseCues(timeWithMixedWhiteSpace);
-  equal(mockTrack.cues_[0].startTime, 0.7, 'Cue start time w/ flags');
-  equal(mockTrack.cues_[0].endTime, 4.11, 'Cue end time w/ flags');
-});
-
 test('Player track methods call the tech', function() {
   var player,
       calls = 0;


### PR DESCRIPTION
Remove video.js's track element emulation and pull in vtt.js to do that work instead. Add an option to force vtt.js-based captions to be used even if native caption support is present. Currently, vtt.js is loaded when the first TextTrack component is created. If vtt.js is not available when it's time to begin parsing cues, poll until it finishes downloading.

This is **not** ready to merge yet.