### PR TITLE
Detect mode change event support and polyfill it if necessary

### DIFF
--- a/src/js/event-emitter.js
+++ b/src/js/event-emitter.js
@@ -37,3 +37,5 @@ vjs.EventEmitter.prototype.trigger = function(event) {
 
   vjs.trigger(this, event);
 };
+// The standard DOM EventTarget.dispatchEvent() is aliased to trigger()
+vjs.EventEmitter.prototype.dispatchEvent = vjs.EventEmitter.prototype.trigger;

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -44,6 +44,10 @@ vjs.TextTrackList = function(tracks) {
 
 vjs.TextTrackList.prototype = vjs.obj.create(vjs.EventEmitter.prototype);
 vjs.TextTrackList.prototype.constructor = vjs.TextTrackList;
+// emulate attribute EventHandler support to allow for feature detection
+vjs.TextTrackList.prototype.onchange = null;
+vjs.TextTrackList.prototype.onaddtrack = null;
+vjs.TextTrackList.prototype.onremovetrack = null;
 
 /*
  * change - One or more tracks in the track list have been enabled or disabled.

--- a/test/unit/tracks/text-track-controls.js
+++ b/test/unit/tracks/text-track-controls.js
@@ -74,3 +74,26 @@ test('menu should update with removeRemoteTextTrack', function() {
   equal(player.controlBar.captionsButton.items.length, 3, 'menu does not contain removed track');
   equal(player.textTracks().length, 1, 'textTracks contains one item');
 });
+
+test('menu items should polyfill mode change events', function() {
+  var player = PlayerTest.makePlayer({}),
+      changes,
+      trackMenuItem;
+
+  // emulate a TextTrackList that doesn't report track mode changes,
+  // like iOS7
+  player.textTracks().onchange = undefined;
+  trackMenuItem = new vjs.TextTrackMenuItem(player, {
+    track: track
+  });
+
+  player.textTracks().on('change', function() {
+    changes++;
+  });
+  changes = 0;
+  trackMenuItem.trigger('tap');
+  equal(changes, 1, 'taps trigger change events');
+
+  trackMenuItem.trigger('click');
+  equal(changes, 2, 'clicks trigger change events');
+});


### PR DESCRIPTION
On iOS7, mode changes to text tracks do not trigger a change event on the associated TextTrackList. That was causing menu items to not update when the currently enabled track was changed and leave all previously selected menu items in the selected state permanently. This change looks for evidence that change event support is in place and if it's not, triggers synthetic change events whenever a menu item is clicked. It does not handle situations where the text track mode was changed programmatically because it doesn't seem possible to detect when native TextTrack objects are in use. In that case, a change event could be fired at the TextTrackList manually to keep everything in sync.