### PR TITLE
Improve logging output from aXe in case of violations

### DIFF
--- a/test/unit/a11y.js
+++ b/test/unit/a11y.js
@@ -21,7 +21,7 @@ q.test('should have no a11y issues, using simple defaults', function(assert) {
   });
 
   axe.a11yCheck('#qunit-fixture', function(results) {
-    console.log(results);
+    console.log(JSON.stringify(results.violations, null, '  '));
     assert.equal(results.violations.length, 0, 'there are no a11y violations');
     done();
   });


### PR DESCRIPTION
Thought you might find this helpful, to improve looking at the aXe output when there are violations.

Although personally I think [#3487](/videojs/video.js/pull/3487) is the way to go ;-)